### PR TITLE
Fix bug calling non-existent DB method

### DIFF
--- a/server.js
+++ b/server.js
@@ -674,7 +674,7 @@ app.post('/api/emails/record', (req, res) => {
 
 // Get all sent emails
 app.get('/api/emails', (req, res) => {
-  database.getSentEmails()
+  database.getEmails()
     .then(emails => {
       res.json({ success: true, emails });
     })


### PR DESCRIPTION
## Summary
- use the correct `getEmails` database function

## Testing
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_684003e834588321bdf799fdcae807ad